### PR TITLE
Add default referral_code to request_api_key

### DIFF
--- a/vectorhub/indexer.py
+++ b/vectorhub/indexer.py
@@ -21,7 +21,7 @@ class ViIndexer:
         else:
             return 'encoder'
 
-    def request_api_key(self, username: str, email: str, referral_code=None):
+    def request_api_key(self, username: str, email: str, referral_code="github_referred"):
         """
         Requesting an API key.
         """

--- a/vectorhub/indexer.py
+++ b/vectorhub/indexer.py
@@ -21,7 +21,7 @@ class ViIndexer:
         else:
             return 'encoder'
 
-    def request_api_key(self, username: str, email: str, referral_code="github_referred"):
+    def request_api_key(self, username: str, email: str, referral_code="vectorhub_referred"):
         """
         Requesting an API key.
         """


### PR DESCRIPTION
Currently, if I try to request an API key, I get the following error:

    >>> from vectorhub.bi_encoders.text_image.torch import Clip2Vec
    >>> model = Clip2Vec()
    >>> model.request_api_key(username='test_user', email='test@example.com')
    API key is being requested. Be sure to save it somewhere!
    {'detail': [{'loc': ['body', 'referral_code'],
       'msg': 'none is not an allowed value',
       'type': 'type_error.none.not_allowed'}]}

Looking at the implementation of [`request_api_key` in vectorai](https://github.com/vector-ai/vectorai/blob/master/vectorai/client.py#L58), it seems that the default value for `referral_code` is `github_referred`instead of `None`.

    >>> model.request_api_key(username='test_user', email='test@example.com',  referral_code="github_referred")
    API key is being requested. Be sure to save it somewhere!
    'OGlSeVJYY0JfVkZqUEN5WldHeDU6LVVtZkJhM2pTU1dRZnBmcFFiQ0ZDdw'